### PR TITLE
Removing navbar pages with old positioning

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -8,11 +8,11 @@ export const NavBar = () => {
       <Headshot />
       <Spacer />
       <Box>
-        <HStack fontSize="sm">
+        {/* <HStack fontSize="sm">
           <Link href="/founders-and-leaders">For Founders and Leaders</Link>
           <Spacer />
           <Link href="/jtbd-practitioners">For JTBD Practitioners</Link>
-        </HStack>
+        </HStack> */}
       </Box>
     </Flex>
   )


### PR DESCRIPTION
Removing "For founders and leaders" and "for jtbd practitioners" pages from nav.